### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/potiboard5/templates/mono_en/icomoon/demo-files/demo.js
+++ b/potiboard5/templates/mono_en/icomoon/demo-files/demo.js
@@ -15,7 +15,7 @@ document.body.addEventListener("click", function(e) {
         testDrive = document.getElementById('testDrive'),
         testText = document.getElementById('testText');
     function updateTest() {
-        testDrive.innerHTML = testText.value || String.fromCharCode(160);
+        testDrive.textContent = testText.value || String.fromCharCode(160);
         if (window.icomoonLiga) {
             window.icomoonLiga(testDrive);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/catharsis71/cracky.win/security/code-scanning/7](https://github.com/catharsis71/cracky.win/security/code-scanning/7)

To fix this issue, we need to ensure that any text assigned to `innerHTML` is properly escaped to prevent the execution of any embedded HTML or scripts. The best way to achieve this is to use `textContent` instead of `innerHTML`, as `textContent` will treat the assigned value as plain text and not interpret it as HTML.

We will replace the assignment to `innerHTML` with an assignment to `textContent` on line 18. This change ensures that any content from `testText.value` is treated as plain text, mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
